### PR TITLE
don't report unknown XML tags when scanning a package

### DIFF
--- a/src/Parser/Cif.php
+++ b/src/Parser/Cif.php
@@ -363,7 +363,9 @@ class Cif extends \C5TL\Parser
                 static::readXmlNodeAttribute($translations, $filenameRel, $node, 'custom-label', 'PageTypeComposerFormLayoutSetControlCustomLabel');
                 break;
             default:
-                throw new \Exception('Unknown tag name '.$path.' in '.$filenameRel."\n\nNode:\n".$node->ownerDocument->saveXML($node));
+                if (strpos($filenameRel, 'packages/') !== false) {
+                    throw new \Exception('Unknown tag name '.$path.' in '.$filenameRel."\n\nNode:\n".$node->ownerDocument->saveXML($node));
+                }
         }
         if ($node->hasChildNodes()) {
             foreach ($node->childNodes as $child) {


### PR DESCRIPTION
I had a custom package with a custom attribute type in it. Scanning this didn't work because I've created a custom CIF import/export function for my attribute type. As discussed, we simply ignore unknown XML tags when scanning a package.
