### PR TITLE
Fixing compatibility issue MySQL 5.7.16

### DIFF
--- a/src/Parser/DynamicItem/Area.php
+++ b/src/Parser/DynamicItem/Area.php
@@ -35,7 +35,7 @@ class Area extends DynamicItem
     public function parseManual(\Gettext\Translations $translations, $concrete5version)
     {
         $db = \Loader::db();
-        $rs = $db->Execute('select distinct (binary arHandle) as AreaName from Areas order by binary arHandle');
+        $rs = $db->Execute('select distinct (binary arHandle) as AreaName from Areas order by binary AreaName');
         while ($row = $rs->FetchRow()) {
             $this->addTranslation($translations, $row['AreaName'], 'AreaName');
         }


### PR DESCRIPTION
Fixes: An exception occurred while executing 'select distinct (binary arHandle) as AreaName from Areas order by arHandle': SQLSTATE[HY000]: General error: 3065 Expression #1 of ORDER BY clause is not in SELECT list, references column 'mosa_website57.Areas.arHandle' which is not in SELECT list; this is incompatible with DISTINCT