### PR TITLE
remove final from private function

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -211,7 +211,7 @@ abstract class Parser
      *
      * @return array[string]
      */
-    final private static function getDirectoryStructureDo($relativePath, $rootDirectory, $exclude3rdParty)
+    private static function getDirectoryStructureDo($relativePath, $rootDirectory, $exclude3rdParty)
     {
         $thisRoot = $rootDirectory;
         if ($relativePath !== '') {


### PR DESCRIPTION
Since a private cannot be overrode (except constructors), let's remove this.
Also this will throw a warning in php 8 so for future use we need to remove this